### PR TITLE
Add button to toggle sound effects

### DIFF
--- a/app/src/main/java/com/franzsarmiento/gridofbits/GameActivity.java
+++ b/app/src/main/java/com/franzsarmiento/gridofbits/GameActivity.java
@@ -201,7 +201,10 @@ public class GameActivity extends Activity {
                 toggle.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
                     @Override
                     public void onCheckedChanged(CompoundButton compoundButton, boolean checked) {
-                        mPlayer.start();
+                        if (SharedPreferencesUtil.getInstance(GameActivity.this)
+                                .isSoundEffectsEnabled()) {
+                            mPlayer.start();
+                        }
                         checkIfWon(final_row, final_col, checked);
                     }
                 });

--- a/app/src/main/java/com/franzsarmiento/gridofbits/HomeActivity.java
+++ b/app/src/main/java/com/franzsarmiento/gridofbits/HomeActivity.java
@@ -25,13 +25,10 @@
 package com.franzsarmiento.gridofbits;
 
 import android.app.Activity;
-import android.content.Context;
 import android.content.Intent;
-import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.view.View;
-import android.widget.RadioButton;
-import android.widget.RadioGroup;
+import android.widget.Button;
 
 
 public class HomeActivity extends Activity {
@@ -40,6 +37,16 @@ public class HomeActivity extends Activity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_home);
+        initaliseSoundEffectButton();
+    }
+
+    private void initaliseSoundEffectButton() {
+        final SharedPreferencesUtil sharedPreferencesUtil = SharedPreferencesUtil.getInstance(this);
+        final boolean soundEffectsEnabled = sharedPreferencesUtil.isSoundEffectsEnabled();
+        final Button soundEffectsButton = (Button) findViewById(R.id.btnSoundEffects);
+        final int buttonText =
+                soundEffectsEnabled ? R.string.sound_effects_on : R.string.sound_effects_off;
+        soundEffectsButton.setText(buttonText);
     }
 
     public void btnPlayEasyOnClick(View view) {
@@ -68,6 +75,20 @@ public class HomeActivity extends Activity {
         HowToPlayDialogFragment dialogFragment = new HowToPlayDialogFragment();
         dialogFragment.show(getFragmentManager(),
                 getResources().getString(R.string.how_to_play));
+    }
+
+    /**
+     * Fired when the Sound Effects button is clicked.
+     * @param view the clicked View.
+     */
+    public void btnSoundEffectsOnClick(final View view) {
+        final SharedPreferencesUtil sharedPreferencesUtil = SharedPreferencesUtil.getInstance(this);
+        // Toggle the previously set value.
+        final boolean soundEffectsEnabled = !sharedPreferencesUtil.isSoundEffectsEnabled();
+        sharedPreferencesUtil.setSoundEffectsEnabled(soundEffectsEnabled);
+        // Reinitialise the Sound Effects Button so that its text reflects the currently saved
+        // value.
+        initaliseSoundEffectButton();
     }
 
     // Return to home screen

--- a/app/src/main/java/com/franzsarmiento/gridofbits/SharedPreferencesUtil.java
+++ b/app/src/main/java/com/franzsarmiento/gridofbits/SharedPreferencesUtil.java
@@ -1,0 +1,54 @@
+package com.franzsarmiento.gridofbits;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.preference.PreferenceManager;
+
+/**
+ * Singleton for accessing SharedPreferences.
+ */
+public class SharedPreferencesUtil {
+
+    private static final String KEY_SOUND_EFFECTS = "soundEffects";
+
+    private static final boolean DEFAULT_SOUND_EFFECTS = true;
+
+    private SharedPreferences sharedPreferences;
+
+    private static SharedPreferencesUtil instance = null;
+
+    /**
+     * Get an instance of the SharedPreferencesUtil.
+     * @param context the Context which will be used to instantiate the SharedPreferencesUtil.
+     * @return if an instance of the SharedPreferencesUtil exists, that instance will be returned
+     * . Otherwise, a new instance will be created.
+     */
+    public static SharedPreferencesUtil getInstance(final Context context) {
+        if (instance == null) {
+            instance = new SharedPreferencesUtil(context);
+        }
+        return instance;
+    }
+
+    private SharedPreferencesUtil(final Context context) {
+        this.sharedPreferences = PreferenceManager.getDefaultSharedPreferences(context);
+    }
+
+    /**
+     * Sets whether sound effects are enabled or disabled.
+     * @param enabled <code>true</code> if sound effects should be played, <code>false</code> if sound
+     * effects should not be played.
+     */
+    public void setSoundEffectsEnabled(final boolean enabled) {
+        this.sharedPreferences.edit().putBoolean(KEY_SOUND_EFFECTS, enabled).commit();
+    }
+
+    /**
+     * Finds out if sound effects are enabled or disabled.
+     * @return <code>true</code> if sound effects should be played, <code>false</code> if sound
+     * effects should not be played.
+     */
+    public boolean isSoundEffectsEnabled() {
+        return this.sharedPreferences.getBoolean(KEY_SOUND_EFFECTS, DEFAULT_SOUND_EFFECTS);
+    }
+}

--- a/app/src/main/res/layout/activity_home.xml
+++ b/app/src/main/res/layout/activity_home.xml
@@ -40,6 +40,11 @@
             android:id="@+id/btnHowToPlay"
             android:onClick="btnHowToPlayOnClick" />
 
+        <Button style="@style/default_base_button"
+                android:text="@string/how_to_play"
+                android:id="@+id/btnSoundEffects"
+                android:onClick="btnSoundEffectsOnClick" />
+
     </LinearLayout>
 
     <TextView

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -51,4 +51,7 @@
     <string name="one">1</string>
     <string name="zero">0</string>
     <string name="ten">10</string>
+
+    <string name="sound_effects_on">Sound Effects On</string>
+    <string name="sound_effects_off">Sound Effects Off</string>
 </resources>


### PR DESCRIPTION
This adds an option to enable/disable sound effects. Previously sound effects could only be disabled by muting the device's audio which can cause problems if the user wishes to listen to audio from another app while playing the game.

For the UI, I tried to adhere to the current style and added the option as a button to the main menu.
